### PR TITLE
Add babel for backward compatibility

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["es2015"],
+  "plugins": ["syntax-async-functions","transform-regenerator"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 .DS_Store
+dist
+test_dist

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+test
+test_dist
+src

--- a/package.json
+++ b/package.json
@@ -2,9 +2,11 @@
   "name": "async-chain-proxy",
   "version": "0.1.3",
   "description": "async-chain-proxy enable to call member functions by method chains.",
-  "main": "src/index.js",
+  "main": "dist/index.js",
   "scripts": {
-    "test": "mocha"
+    "pretest": "babel test --source-maps --out-dir test_dist",
+    "test": "mocha test_dist",
+    "build": "babel src --source-maps --out-dir dist --ignore '**/*.test.js'"
   },
   "repository": {
     "type": "git",
@@ -13,7 +15,13 @@
   "bugs": "https://github.com/OnetapInc/async-chain-porxy/issues",
   "author": "yamada <yamada@enty.jp>",
   "license": "MIT",
+  "dependencies": {
+    "babel-polyfill": "^6.23.0"
+  },
   "devDependencies": {
+    "babel-cli": "^6.24.1",
+    "babel-plugin-syntax-async-functions": "^6.13.0",
+    "babel-preset-es2015": "^6.24.1",
     "mocha": "^3.3.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 
+import 'babel-polyfill';
 const RESULT_FUNCTION_NAME = '___RESULT_FUNCTION'
 
 class ChainObject {

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
-const chainProxy = require('../src')
+const chainProxy = require('../dist')
 const assert = require('assert')
 
 class ForTest {


### PR DESCRIPTION
RE: https://github.com/OnetapInc/chromy/pull/19#issuecomment-311816316

It’s because we need to include the regenerator run time. The runtime is packed in the babel-polyfill we have already installed. We just need to include it in our source code