### PR TITLE
fix(deps): add babel-runtime to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "author": "yamada <yamada@enty.jp>",
   "license": "MIT",
   "dependencies": {
-    "babel-polyfill": "^6.23.0"
+    "babel-polyfill": "^6.23.0",
+    "babel-runtime": "^6.23.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",


### PR DESCRIPTION
babel-runtime is used in the compiled code, so it should be a dependency.

fixes pnpm/pnpm#1925